### PR TITLE
adds bluespace miners

### DIFF
--- a/code/controllers/configuration/entries/game_options.dm
+++ b/code/controllers/configuration/entries/game_options.dm
@@ -364,6 +364,12 @@
 	integer = FALSE
 	min_val = 0
 
+//Bluespace Miners
+/datum/config_entry/number/roundstart_bluespace_miners
+	min_val = 0
+
+/datum/config_entry/flag/bsminer_researchable
+
 /datum/config_entry/flag/allow_random_events // Enables random events mid-round when set
 
 /datum/config_entry/flag/forbid_station_traits

--- a/code/game/objects/items/circuitboards/machines/machine_circuitboards.dm
+++ b/code/game/objects/items/circuitboards/machines/machine_circuitboards.dm
@@ -935,6 +935,17 @@
 
 //Science
 
+/obj/item/circuitboard/machine/bluespace_miner
+	name = "bluespace miner (Machine Board)"
+	build_path = /obj/machinery/mineral/bluespace_miner
+	req_components = list(
+		/obj/item/stock_parts/matter_bin = 3,
+		/obj/item/stock_parts/micro_laser = 1,
+		/obj/item/stock_parts/manipulator = 3,
+		/obj/item/stock_parts/scanning_module = 1,
+		/obj/item/stack/ore/bluespace_crystal = 3)
+	needs_anchored = FALSE
+
 /obj/item/circuitboard/machine/circuit_imprinter/department/science
 	name = "Departmental Circuit Imprinter - Science"
 	greyscale_colors = CIRCUIT_COLOR_SCIENCE

--- a/code/game/objects/structures/crates_lockers/closets/secure/scientist.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/scientist.dm
@@ -17,6 +17,10 @@
 	new /obj/item/storage/photo_album/rd(src)
 	new /obj/item/storage/box/skillchips/science(src)
 
+	if(CONFIG_GET(number/roundstart_bluespace_miners))
+		for(var/i in 1 to CONFIG_GET(number/roundstart_bluespace_miners))
+			new /obj/item/circuitboard/machine/bluespace_miner(src)
+
 /obj/structure/closet/secure_closet/research_director/populate_contents_immediate()
 	. = ..()
 

--- a/code/modules/mining/machine_bluespaceminer.dm
+++ b/code/modules/mining/machine_bluespaceminer.dm
@@ -1,0 +1,42 @@
+/obj/machinery/mineral/bluespace_miner
+	name = "bluespace mining machine"
+	desc = "A machine that uses the magic of Bluespace to slowly generate materials and add them to a linked ore silo."
+	icon = 'icons/obj/machines/mining_machines.dmi'
+	icon_state = "stacker"
+	density = TRUE
+	circuit = /obj/item/circuitboard/machine/bluespace_miner
+	layer = BELOW_OBJ_LAYER
+	var/list/ore_rates = list(/datum/material/iron = 0.6, /datum/material/glass = 0.6, /datum/material/plasma = 0.2,  /datum/material/silver = 0.2, /datum/material/gold = 0.1, /datum/material/titanium = 0.1, /datum/material/uranium = 0.1, /datum/material/diamond = 0.1)
+	var/datum/component/remote_materials/materials
+	processing_flags = START_PROCESSING_MANUALLY
+
+/obj/machinery/mineral/bluespace_miner/Initialize(mapload)
+	. = ..()
+	materials = AddComponent(/datum/component/remote_materials, "bsm", mapload)
+	START_PROCESSING(SSmachines,src)
+
+/obj/machinery/mineral/bluespace_miner/Destroy()
+	materials = null
+	return ..()
+
+/obj/machinery/mineral/bluespace_miner/multitool_act(mob/living/user, obj/item/multitool/M)
+	if(istype(M))
+		if(!M.buffer || !istype(M.buffer, /obj/machinery/ore_silo))
+			to_chat(user, "<span class='warning'>You need to multitool the ore silo first.</span>")
+			return FALSE
+
+/obj/machinery/mineral/bluespace_miner/examine(mob/user)
+	. = ..()
+	if(!materials?.silo)
+		. += "<span class='notice'>No ore silo connected. Use a multi-tool to link an ore silo to this machine.</span>"
+	else if(materials?.on_hold())
+		. += "<span class='warning'>Ore silo access is on hold, please contact the quartermaster.</span>"
+
+/obj/machinery/mineral/bluespace_miner/process()
+	if(!materials?.silo || materials?.on_hold())
+		return
+	var/datum/component/material_container/mat_container = materials.mat_container
+	if(!mat_container || panel_open || !powered())
+		return
+	var/datum/material/ore = pick(ore_rates)
+	mat_container.insert_amount_mat((ore_rates[ore] * 1000), ore)

--- a/code/modules/research/designs/machine_designs.dm
+++ b/code/modules/research/designs/machine_designs.dm
@@ -683,6 +683,16 @@
 	)
 	departmental_flags = DEPARTMENT_BITFLAG_SCIENCE | DEPARTMENT_BITFLAG_CARGO | DEPARTMENT_BITFLAG_ENGINEERING
 
+/datum/design/board/bluespace_miner
+	name = "Machine Design (Bluespace Miner)"
+	desc = "The circuit board for a Bluespace Miner."
+	id = "bluespace_miner"
+	build_path = /obj/item/circuitboard/machine/bluespace_miner
+	category = list(
+		RND_CATEGORY_MACHINE + RND_SUBCATEGORY_MACHINE_CARGO
+	)
+	departmental_flags = DEPARTMENT_BITFLAG_SCIENCE | DEPARTMENT_BITFLAG_CARGO | DEPARTMENT_BITFLAG_ENGINEERING
+
 /datum/design/board/mining_equipment_vendor
 	name = "Mining Rewards Vendor Board"
 	desc = "The circuit board for a Mining Rewards Vendor."

--- a/code/modules/research/techweb/mining_nodes.dm
+++ b/code/modules/research/techweb/mining_nodes.dm
@@ -54,3 +54,17 @@
 	)
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 7500)
 	discount_experiments = list(/datum/experiment/scanning/random/material/hard/one = 5000)
+
+/datum/techweb_node/bluespace_mining
+	id = "bluespace_mining"
+	hidden = TRUE
+	display_name = "Bluespace Mining Technology"
+	description = "Harness the power of bluespace to make materials out of nothing. Slowly."
+	prereq_ids = list("basic_mining")
+	design_ids = list("bluespace_miner")
+	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2500)
+
+/datum/techweb_node/bluespace_mining/New() //Techweb nodes don't have an init,
+	. = ..()
+
+	hidden = !CONFIG_GET(flag/bsminer_researchable)

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -495,6 +495,14 @@ MICE_ROUNDSTART 5
 ## If the percentage of players alive (doesn't count conversions) drops below this threshold the emergency shuttle will be forcefully called (provided it can be)
 #EMERGENCY_SHUTTLE_AUTOCALL_THRESHOLD 0.2
 
+## Bluespace Miners.
+
+## Amount of miner boards in the RD's locker at roundstart.
+ROUNDSTART_BLUESPACE_MINERS 0
+
+## Enable the bluespace miner research node?
+BSMINER_RESEARCHABLE
+
 ## Uncomment to allow roundstart quirk selection in the character setup menu.
 ## This used to be named traits, hence the config name, but it handles quirks, not the other kind of trait!
 ROUNDSTART_TRAITS

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -4350,6 +4350,7 @@
 #include "code\modules\mining\abandoned_crates.dm"
 #include "code\modules\mining\aux_base.dm"
 #include "code\modules\mining\fulton.dm"
+#include "code\modules\mining\machine_bluespaceminer.dm"
 #include "code\modules\mining\machine_processing.dm"
 #include "code\modules\mining\machine_redemption.dm"
 #include "code\modules\mining\machine_silo.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds the bluespace miner, sacrifice three bluespace crystals (found in station teleporters) and get a reliable source of very slow materials, you can make up to three shiftstart and go as far as you want from there to replace miners.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
miners on this server probably won't care about mining, we don't even have miner players at the moment anyways
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog
:cl:
add: Bluespace Miners
/:cl:
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Bluespace Miners
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
